### PR TITLE
Added important missing methods to the object

### DIFF
--- a/bindings/vue/src/index.js
+++ b/bindings/vue/src/index.js
@@ -47,6 +47,7 @@ const install = (Vue, params = {}) => {
    */
   Vue.prototype.$ons = Object.keys(ons)
     .filter(k => [
+      /^is/,
       /^disable/,
       /^enable/,
       /^open/,


### PR DESCRIPTION
In the documentation (https://onsen.io/v2/api/vue/$ons.html) we can see other important methods, but in definition of object these methods do not exist.